### PR TITLE
支持动态使用 YYModel 序列化方法

### DIFF
--- a/dsbridge/JSBUtil.m
+++ b/dsbridge/JSBUtil.m
@@ -15,17 +15,32 @@
     NSString *jsonString = nil;
     NSError *error;
     
-    if (![NSJSONSerialization isValidJSONObject:dict]) {
+    id json = [self modelToJSONObject:dict];
+    
+    if (![NSJSONSerialization isValidJSONObject:json]) {
         return @"{}";
     }
     
-    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:dict options:0 error:&error];
-    if (! jsonData) {
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:json options:0 error:&error];
+    if (!jsonData) {
         return @"{}";
     } else {
         jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
     }
     return jsonString;
+}
+
+//call YYModel methods
++ (id)modelToJSONObject:(id _Nonnull)model
+{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
+    if ([model respondsToSelector:@selector(yy_modelToJSONObject)]) {
+        return [model performSelector:@selector(yy_modelToJSONObject)];
+#pragma clang diagnostic pop
+    } else {
+        return model;
+    }
 }
 
 //get this class all method


### PR DESCRIPTION
增强 `+ (NSString *)objToJsonString:(id)dict` 方法。

当用户使用 yymodel 时，传入的数组，使用 YYModel 的 objectToJSONObject 将 model 序列化成 NSArray 和 NSDictionary 。

这样在传输参数的时候，就能够比较方便的直接使用 Object（将 readwrite 的属性自动转成 JSON 内容）。

未使用 YYModel 的用户，无感知。
使用了 YYModel，但是自己序列化过的用户也没有影响（YYModel 不会处理字符串，数字；字典和数组如果已经通过 `[NSJSONSerialization isValidJSONObject:obj]` 检查，也不会进行序列化）。