### PR TITLE
Fix: complete handler must be call before wkwebview dealloc. If not c…

### DIFF
--- a/dsbridge.xcodeproj/project.pbxproj
+++ b/dsbridge.xcodeproj/project.pbxproj
@@ -466,7 +466,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "dsbridgedemo/dsbridgedemo-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -483,7 +483,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = wendu.dsbridgedemo.xx;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "dsbridgedemo/dsbridgedemo-Bridging-Header.h";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/dsbridge/DWKWebView.m
+++ b/dsbridge/DWKWebView.m
@@ -24,6 +24,18 @@
     bool isDebug;
 }
 
+-(void)dealloc {
+    if(dialogType==1 && alertHandler){
+        alertHandler();
+        alertHandler=nil;
+    }else if(dialogType==2 && confirmHandler){
+        confirmHandler(NO);
+        confirmHandler=nil;
+    }else if(dialogType==3 && promptHandler) {
+        promptHandler(@"");
+        promptHandler=nil;
+    }
+}
 
 -(instancetype)initWithFrame:(CGRect)frame configuration:(WKWebViewConfiguration *)configuration
 {


### PR DESCRIPTION
…alled, webview will be crash. When H5 alert( comfirm/ promot) something, and webview dealloc, then the dwkwebview will crash.